### PR TITLE
Add automatic handling of belongs_to association sorting

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,7 +28,13 @@ This will initially sort by email ascending:
 
   @users = User.sorted(:order => "email ASC", :sort => params[:sort]).paginate(:page => params[:page])
 
-Or you can just clone the example app https://github.com/mynameisrufus/sorted_app
+Or you can just clone the example app https://github.com/mynameisrufus/sorted_app.
+
+If you want to sort by a belongs_to relationship, just provide sort order as "RELATIONS.COLUMN ASC|DESC" where
+RELATIONS is the name of the relationship table and COLUMN is an attribute in that table.  For example, 
+assuming the User model belongs_to a :company.
+
+  @users = User.sorted(:order => "companies.name asc", :sort => params[:sort]).paginate(:page => params[:page])
 
 == Presentation
 

--- a/lib/sorted/finders/active_record.rb
+++ b/lib/sorted/finders/active_record.rb
@@ -7,7 +7,17 @@ module Sorted
       def self.enable!
         ::ActiveRecord::Base.class_eval do
           def self.sorted(params)
-            order(::Sorted::Sorter.new(params[:order], :sort => params[:sort]).to_sql)
+            sorter = ::Sorted::Sorter.new(params[:order], :sort => params[:sort])
+            # Check if we parsed some relationship includes and apply them
+            # before applying the order
+            relation = self
+            if sorter.includes.size > 0
+              # Remove self.name from includes
+              my_name = self.name.to_sym
+              real_includes = sorter.includes.remove_if{|include_name| include_name == my_name}
+              relation = includes(real_includes) if real_includes.size > 0
+            end
+            relation.order(sorter.to_sql)
           end
         end
       end

--- a/lib/sorted/sorter.rb
+++ b/lib/sorted/sorter.rb
@@ -1,6 +1,8 @@
 module Sorted
   class Sorter
+    attr_reader :includes
     def initialize(order, params = nil)
+      @includes = []
       if order.is_a?(String) || order.is_a?(Symbol)
         parse_order(order)
       end
@@ -30,13 +32,23 @@ module Sorted
     
     def parse_query(sort)
       if m = sort.match(/([a-zA-Z0-9._]+)_(asc|desc)$/)
+        parse_include(m[1])
         [m[1],m[2]]
       end
     end
 
     def parse_sql(order)
       if m = order.match(/(([a-zA-Z._:]+)\s([asc|ASC|desc|DESC]+)|[a-zA-Z._:]+)/)
-        [(m[2].nil? ? m[1] : m[2]),(m[3].nil? ? "asc" : m[3].downcase)]
+        sort_column = (m[2].nil? ? m[1] : m[2])
+        parse_include(sort_column)
+        [sort_column,(m[3].nil? ? "asc" : m[3].downcase)]
+      end
+    end
+
+    def parse_include(order)
+      if match_data = /^([^\.]+)\..+/.match(order)
+        include_name = match_data[1].singularize.to_sym
+        @includes << include_name unless @includes.include?(include_name)
       end
     end
 

--- a/spec/sorter_spec.rb
+++ b/spec/sorter_spec.rb
@@ -20,6 +20,7 @@ describe Sorted::Sorter, "parse methods" do
   it "should allow underscores, full stops and colons in" do
     sorter = Sorted::Sorter.new('users.email ASC, users.phone_number DESC, assessments.name ASC, assessments.number_as_string::BigInt', {:sort => "users.email_desc!users.first_name_desc"})
     sorter.to_sql.should == "users.email DESC, users.first_name DESC, users.phone_number DESC, assessments.name ASC, assessments.number_as_string::BigInt ASC"
+    sorter.includes.size.should == 2
   end
 end
 
@@ -27,6 +28,7 @@ describe Sorted::Sorter, "logic:" do
   it "should not toggle the sort order and include any sql orders not in sort params" do
     sorter = Sorted::Sorter.new("email ASC, phone ASC, name DESC", {:sort => "email_desc!name_desc"})
     sorter.to_a.should == [["email", "desc"], ["name", "desc"], ["phone", "asc"]]
+    sorter.includes.size.should == 0
   end
 
   it "should return an sql sort string" do


### PR DESCRIPTION
Hello,
I had the need to sort a model by an attribute of a belongs_to association model.  I didn't see any easy way to handle the sorted_link_to doing the right thing without adding code to basically preparse the sort parameter in the controller.  I thought it worked better having the Sorted::Sorter class handle it.  Take a look at the implementation and let me know what you think.  I added some assertions to the sorted_spec to verify it is working correctly.

The only thing I don't like about it is if somebody specifies the sort order for model Foo as foos.column instead of simply 'column'.  The Sorted::Sorter class will think that 'foos' is a belongs_to relationship table.  This is taken care of in the ActiveRecord#sorted method, but it is messy.

Cheers,
Doug Seifert
