### PR TITLE
Numbers in Columns & Symbolic Sorts

### DIFF
--- a/.watchr
+++ b/.watchr
@@ -1,0 +1,24 @@
+module WatchrActions
+  def self.run_spec(file)
+    unless File.exist?(file)
+      puts "#{file} does not exist"
+      return
+    end
+
+    puts "Running #{file}"
+    system "rspec #{file}"
+  end
+end
+
+watch(/^lib\/(?:sorted\/)?(.*).rb/) do |m|
+  WatchrActions.run_spec("spec/#{m[1]}_spec.rb")
+end
+
+watch(/^spec\/.*_spec.rb/) do |m|
+  WatchrActions.run_spec(m[0])
+end
+
+watch(/^lib\/sorted\/finders\/active_record.rb/) do |m|
+  WatchrActions.run_spec('spec/sorted_spec.rb')
+end
+

--- a/lib/sorted/finders/active_record.rb
+++ b/lib/sorted/finders/active_record.rb
@@ -6,8 +6,17 @@ module Sorted
     module ActiveRecord
       def self.enable!
         ::ActiveRecord::Base.class_eval do
+          # Define a symbolic sort column. This allows mapping a simple column name
+          # to a more complex sql order clause.
+          #  class Model < ActiveRecord::Base
+          #    symbolic_sort :ip_address, 'inet_aton(`ip_address`)'
+          #  end
+          def self.symbolic_sort(key, sql)
+            symbolic_sorts[key] = sql
+          end
+
           def self.sorted(params)
-            sorter = ::Sorted::Sorter.new(params[:order], :sort => params[:sort])
+            sorter = ::Sorted::Sorter.new(params[:order], :sort => params[:sort], :symbolic_sorts => symbolic_sorts)
             # Check if we parsed some relationship includes and apply them
             # before applying the order
             relation = self
@@ -18,6 +27,12 @@ module Sorted
               relation = includes(real_includes) if real_includes.size > 0
             end
             relation.order(sorter.to_sql)
+          end
+
+          private
+
+          def self.symbolic_sorts
+            @symbolic_sorts ||= {}
           end
         end
       end

--- a/lib/sorted/sorter.rb
+++ b/lib/sorted/sorter.rb
@@ -3,6 +3,8 @@ module Sorted
     attr_reader :includes
     def initialize(order, params = nil)
       @includes = []
+      @symbolic_sorts = {}
+
       if order.is_a?(String) || order.is_a?(Symbol)
         parse_order(order)
       end
@@ -11,6 +13,7 @@ module Sorted
         if @params[:sort].is_a?(String) 
           parse_sort @params[:sort]
         end
+        @symbolic_sorts = @params[:symbolic_sorts] || {}
       end
     end
     
@@ -67,7 +70,10 @@ module Sorted
     end
     
     def to_sql
-      array.map{|a| "#{a[0]} #{a[1].upcase}"}.join(', ')
+      array.map do |a|
+        column = @symbolic_sorts[a[0].to_sym] || a[0]
+        "#{column} #{a[1].upcase}"
+      end.join(', ')
     end
 
     def to_s

--- a/spec/sorted_spec.rb
+++ b/spec/sorted_spec.rb
@@ -10,6 +10,34 @@ describe Sorted::Finders::ActiveRecord do
   it "should integrate with ActiveRecord::Base" do
     ActiveRecord::Base.should respond_to(:sorted)
   end
+
+  it "should define a symbolic_sorts method" do
+    ActiveRecord::Base.should respond_to(:symbolic_sort)
+  end
+
+  it "should define symbolic_sorts" do
+    a = Class.new(ActiveRecord::Base)
+    b = Class.new(ActiveRecord::Base)
+
+    a.symbolic_sort(:foo, 'foo')
+    b.symbolic_sort(:bar, 'bar')
+
+    a.instance_variable_get(:@symbolic_sorts).should == {:foo => 'foo'}
+    b.instance_variable_get(:@symbolic_sorts).should == {:bar => 'bar'}
+  end
+
+  it "should add orders to the relation" do
+    a = Class.new(ActiveRecord::Base)
+    relation = a.sorted(:order => nil, :sort => 'a_asc')
+    relation.order_values.should == ["a ASC"]
+  end
+
+  it "should add orders to the relation using symbolic_sorts" do
+    a = Class.new(ActiveRecord::Base)
+    a.symbolic_sort(:ip, 'inet_aton(`ip`)')
+    relation = a.sorted(:order => nil, :sort => 'ip_asc')
+    relation.order_values.should == ["inet_aton(`ip`) ASC"]
+  end
 end
 
 describe Sorted::ViewHelpers::ActionView do

--- a/spec/sorter_spec.rb
+++ b/spec/sorter_spec.rb
@@ -45,6 +45,11 @@ describe Sorted::Sorter, "logic:" do
     sorter = Sorted::Sorter.new('email ASC, phone DESC, name ASC', {:sort => "email_desc!name_desc"})
     sorter.to_sql.should == "email DESC, name DESC, phone DESC"
   end
+
+  it "should substitute symbolic sorts" do
+    sorter = Sorted::Sorter.new('ip_address', :symbolic_sorts => {:ip_address => 'inet_aton(`ip_address`)'})
+    sorter.to_sql.should == "inet_aton(`ip_address`) ASC"
+  end
 end
 
 describe Sorted::Sorter, "to_css" do


### PR DESCRIPTION
1. Allow numbers in columns.
   Parse SQL didn't previously allow number in column names. The regexes now allow numbers after the first character.
2. Symbolic sorts.
   This is my solution to wanting to sort ip addresses stored as strings in the database. I wanted to sort on inet_aton(ip_address), but still have a friendly url.

With the patch you now define symbolic sorts in your model:

```
class Model < ActiveRecord::Base
  symbolic_sort :ip, 'inet_aton(ip_address)'
end
```

When generating sql with a sort string like `ip_asc` the generated sql will read `inet_aton(ip_address) ASC`.
