### PR TITLE
Pass empty params from link_to_sort helper when request is POST

### DIFF
--- a/lib/sorted/view_helpers/action_view.rb
+++ b/lib/sorted/view_helpers/action_view.rb
@@ -24,7 +24,7 @@ module Sorted
       end
 
       def link_to_sorted(name, order, options = {})
-        sorter          = SortedViewHelper.new(order, ((request.get? && !params.nil?) ? params.dup : nil))
+        sorter          = SortedViewHelper.new(order, ((request.get? && !params.nil?) ? params.dup : {}))
         options[:class] = [options[:class], sorter.css].join(' ').strip
         link_to(name.to_s, sorter.params, options)
       end

--- a/spec/sorted/view_helpers/action_view_spec.rb
+++ b/spec/sorted/view_helpers/action_view_spec.rb
@@ -34,4 +34,12 @@ describe Sorted::ViewHelpers::ActionView::SortedViewHelper do
     sorter = Sorted::ViewHelpers::ActionView::SortedViewHelper.new order, params
     sorter.css.should eq result
   end
+
+  it "should return the default order when params are empty" do
+    order  = :email
+    result = { :sort => "email_asc" }
+
+    sorter = Sorted::ViewHelpers::ActionView::SortedViewHelper.new order, {}
+    sorter.params.should eq result
+  end
 end


### PR DESCRIPTION
The `link_to_sort` helper was throwing the following exception if it was called during a POST request (for example, after re-rendering a template during a failed `create` call in Rails)

```
undefined method `delete' for nil:NilClass
```

Instead of passing `nil` to the `SortedViewHelper`, I passed an empty hash which will result in a default sorting and no exception. 
