### PR TITLE
Added convenience method for creating sort link menus.

### DIFF
--- a/lib/sorted/view_helpers/action_view.rb
+++ b/lib/sorted/view_helpers/action_view.rb
@@ -56,6 +56,31 @@ module Sorted
         options[:class] = [options[:class], sorter.css].join(' ').strip
         link_to(sorter.params, options, html_options, &block)
       end
+
+      # Convenience method for quickly spitting out a sorting menu.
+      #
+      # ==== Examples
+      #
+      # Basic usage
+      #
+      #   sort_by :first_name, :last_name
+      #
+      # To provide a string to use instead of a column name, pass an array composed
+      # of your label string and the column name (symbol):
+      #
+      #   sortable_by :author_name, :title, ["Date of Publication", :published_at]
+      #
+      def sortable_by(*columns)
+        links = content_tag :span, "Sort by: "
+        columns.each do |c|
+          if c.is_a? Array
+            links += link_to_sorted(c[0],c[1].to_sym)
+          else
+            links += link_to_sorted(c.to_s.titleize, c.to_sym)
+          end
+        end
+        content_tag :div, links, :class => 'sortable'
+      end
     end
   end
 end


### PR DESCRIPTION
Thanks for making this very helpful gem. I use it in a lot of my apps, and in each of them I've been using this helper method to quickly spit out a menu of sort links. I thought it might be useful to others.

```
# Basic usage
sortable_by :first_name, :last_name

# Label override
sortable_by :title, :author_name, ["Publication Date", :published_at]
```

Re: specs -- I don't really know how to do view helper testing in a plugin, I tried to copy your specs for `link_to_sorted` but didn't see (or perhaps understand) them. If you have suggestions on this let me know.
