### PR TITLE
database-independent column quoting

### DIFF
--- a/lib/sorted/orms/active_record.rb
+++ b/lib/sorted/orms/active_record.rb
@@ -10,7 +10,7 @@ module Sorted
       included do
         def self.sorted(sort, default_order = nil)
           sorter = ::Sorted::Parser.new(sort, default_order)
-          order sorter.to_sql
+          order sorter.to_sql(self.connection)
         end
       end
     end

--- a/lib/sorted/parser.rb
+++ b/lib/sorted/parser.rb
@@ -40,9 +40,9 @@ module Sorted
       array.inject({}){|h,a| h.merge(Hash[a[0],a[1]])}
     end
 
-    def to_sql
+    def to_sql(conn)
       array.map do |a|
-        column = a[0].split('.').map{ |fragment| "`#{fragment}`" }.join('.')
+        column = a[0].split('.').map{ |frag| conn.quote_column_name frag }.join('.')
         "#{column} #{a[1].upcase}"
       end.join(', ')
     end

--- a/spec/sorted/orms/active_record_spec.rb
+++ b/spec/sorted/orms/active_record_spec.rb
@@ -18,7 +18,7 @@ describe Sorted::Orms::ActiveRecord do
   end
 
   it "should play nice with other scopes" do
-    sql = "SELECT  \"sorted_active_record_tests\".* FROM \"sorted_active_record_tests\"  WHERE \"sorted_active_record_tests\".\"name\" = 'bob'  ORDER BY `name` ASC LIMIT 50"
+    sql = "SELECT  \"sorted_active_record_tests\".* FROM \"sorted_active_record_tests\"  WHERE \"sorted_active_record_tests\".\"name\" = 'bob'  ORDER BY \"name\" ASC LIMIT 50"
     SortedActiveRecordTest.where(:name => 'bob').page.sorted(nil, 'name ASC').to_sql.should == sql
     SortedActiveRecordTest.page.sorted(nil, 'name ASC').where(:name => 'bob').to_sql.should == sql
   end

--- a/spec/sorted/parser_spec.rb
+++ b/spec/sorted/parser_spec.rb
@@ -61,13 +61,18 @@ describe Sorted::Parser, "params parsing" do
 end
 
 describe Sorted::Parser, "return types" do
+  module FakeConnection
+    def self.quote_column_name(column_name)
+      "`#{column_name}`"
+    end
+  end
 
   it "should properly escape sql column names" do
     order = "users.name DESC"
     result = "`users`.`name` DESC"
 
     sorter = Sorted::Parser.new(nil, order)
-    sorter.to_sql.should eq result
+    sorter.to_sql(FakeConnection).should eq result
   end
 
   it "should return an sql sort string" do
@@ -76,7 +81,7 @@ describe Sorted::Parser, "return types" do
     result = "`email` DESC, `name` DESC, `phone` ASC"
 
     sorter = Sorted::Parser.new(sort, order)
-    sorter.to_sql.should eq result
+    sorter.to_sql(FakeConnection).should eq result
   end
 
   it "should return an hash" do
@@ -103,6 +108,6 @@ describe Sorted::Parser, "return types" do
     result = "`email` ASC, `phone` ASC, `name` DESC"
 
     sorter = Sorted::Parser.new(sort, order)
-    sorter.to_sql.should eq result
+    sorter.to_sql(FakeConnection).should eq result
   end
 end


### PR DESCRIPTION
I don't think the parser's current `to_sql` method will work with postgres, which escapes column names with double quotes rather than backticks.

I've update the method to use `ActiveRecord::ConnectionAdapters::Quoting#quote_column_name` to do the quoting. This means passing a copy of the DB connection adapter into the to_sql method, which I think is fine (this method should only work with ActiveRecord anyway, right?)

Might be worth setting travis up to test against multiple database backends, which I have not attempted here.
