### PR TITLE
generates urls correctly under rails 4

### DIFF
--- a/lib/sorted/view_helpers/action_view.rb
+++ b/lib/sorted/view_helpers/action_view.rb
@@ -54,7 +54,7 @@ module Sorted
 
         sorter          = SortedViewHelper.new(order, ((request.get? && !params.nil?) ? params.dup : {}))
         options[:class] = [options[:class], sorter.css].join(' ').strip
-        link_to(sorter.params, options, html_options, &block)
+        link_to(url_for(sorter.params), options, html_options, &block)
       end
 
       # Convenience method for quickly spitting out a sorting menu.


### PR DESCRIPTION
Looks like passing the sorter params hash as the first arg to `link_to` doesn't work anymore - this patch sends them through `url_for` first
