### PR TITLE
Introduce sorted! to override the previous order

### DIFF
--- a/lib/sorted/orms/active_record.rb
+++ b/lib/sorted/orms/active_record.rb
@@ -8,9 +8,25 @@ module Sorted
 
       included do
         def self.sorted(sort, default_order = nil)
-          sorter = ::Sorted::Parser.new(sort, default_order)
-          quoter = ->(frag) { connection.quote_column_name(frag) }
-          order sorter.to_sql(quoter)
+          order sort_sql(sort, default_order)
+        end
+
+        def self.sorted!(sort, default_order = nil)
+          reorder sort_sql(sort, default_order)
+        end
+
+        private
+
+        def self.sort_sql(sort, default_order)
+          sorter(sort, default_order).to_sql(quoter)
+        end
+
+        def self.sorter(sort, default_order)
+          ::Sorted::Parser.new(sort, default_order)
+        end
+
+        def self.quoter
+          ->(frag) { connection.quote_column_name(frag) }
         end
       end
     end

--- a/spec/sorted/orms/active_record_spec.rb
+++ b/spec/sorted/orms/active_record_spec.rb
@@ -16,12 +16,18 @@ if defined? ActiveRecord
 
     it "should integrate with ActiveRecord::Base" do
       SortedActiveRecordTest.should respond_to(:sorted)
+      SortedActiveRecordTest.should respond_to(:sorted!)
     end
 
     it "should play nice with other scopes" do
       sql = "SELECT  \"sorted_active_record_tests\".* FROM \"sorted_active_record_tests\"  WHERE \"sorted_active_record_tests\".\"name\" = 'bob'  ORDER BY \"name\" ASC LIMIT 50"
       SortedActiveRecordTest.where(:name => 'bob').page.sorted(nil, 'name ASC').to_sql.should == sql
       SortedActiveRecordTest.page.sorted(nil, 'name ASC').where(:name => 'bob').to_sql.should == sql
+    end
+
+    it "should override the provided order" do
+      sql = "SELECT  \"sorted_active_record_tests\".* FROM \"sorted_active_record_tests\"  WHERE \"sorted_active_record_tests\".\"name\" = 'bob'  ORDER BY \"name\" ASC LIMIT 50"
+      SortedActiveRecordTest.page.where(:name => 'bob').order(:id).sorted!(nil, 'name ASC').to_sql.should == sql
     end
   end
 end


### PR DESCRIPTION
The aim of this PR is to only rely on the sorted gem in some cases and to override the previous order that might have been set previously.  
